### PR TITLE
Added method to reshape dims of network.

### DIFF
--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -487,7 +487,7 @@ class Network(qutip.core.data.Data):
         because there may be some ambiguity in how to transpose the required
         indices.
         >>>dim_in = (3,2)
-        >>>dim_out= (2,3)
+        >>>dim_out = (2,3)
         >>>array = np.random.random()
         >>>right = tn.Node(np.random.random(dim_in))
         >>>left = tn.Node(np.random.random(dim_out))
@@ -581,10 +581,6 @@ class Network(qutip.core.data.Data):
         ``target_dims``. After this function the following will hold:
             ``network.dims[0] == target_dims``
 
-        Note
-        ----
-        This is an in-place operation that returns itself.
-
         Parameters
         ----------
         target_dims: list of int
@@ -601,7 +597,7 @@ class Network(qutip.core.data.Data):
         >>> array = np.random.random(network_dim)
         >>> node = tn.Node(array)
         >>> network = Network(node[:], [])
-        >>> network.match_out_dims(target_dims)
+        >>> network = network.match_out_dims(target_dims)
 
         Raises
         ------
@@ -613,18 +609,15 @@ class Network(qutip.core.data.Data):
         --------
         match_in_dims
         """
-        edges = _match_dimensions(self.out_edges, target_dims)
-        self.out_edges = edges
-        return self
+        out = self.copy()
+        edges = _match_dimensions(out.out_edges, target_dims)
+        out.out_edges = edges
+        return out
 
     def match_in_dims(self, target_dims):
         """Reshape nodes by splitting edges such that `in_edges` matches
         ``target_dims``. After this function the following will hold:
             ``network.dims[1] == target_dims``
-
-        Note
-        ----
-        This is an in-place operation that returns itself.
 
         Parameters
         ----------
@@ -642,7 +635,7 @@ class Network(qutip.core.data.Data):
         >>> array = np.random.random(network_dim)
         >>> node = tn.Node(array)
         >>> network = Network(node[:], [])
-        >>> network.match_out_dims(target_dims)
+        >>> network = network.match_out_dims(target_dims)
 
         Raises
         ------
@@ -654,9 +647,10 @@ class Network(qutip.core.data.Data):
         --------
         match_out_dims
         """
-        edges = _match_dimensions(self.in_edges, target_dims)
-        self.in_edges = edges
-        return self
+        out = self.copy()
+        edges = _match_dimensions(out.in_edges, target_dims)
+        out.in_edges = edges
+        return out
 
 
 def _match_edges_by_split(out_edges, in_edges):
@@ -774,21 +768,19 @@ def _match_dimensions(edges, target_dims):
     >>> node = tn.Node(array)
     >>> network = Network(node[:], [])
     >>> _match_dimensions(network.in_edges, target_dims)
-    ValueError
 
     Since only splitting of edges are allowed, the next example will raise a
     ValueError:
-    
     >>> network_dim = [2, 2]
     >>> target_dims = [4]
     >>> array = np.random.random(network_dim)
     >>> node = tn.Node(array)
     >>> network = Network(node[:], [])
-    >>> _match_dimensions(network.in_edges, target_dims)
-    ValueError
+    >>> _match_dimensions(network.in_edges, target_dims) # ValueError
     """
 
     edges = edges[:]
+
     target_dims = target_dims[:]
     _target_dims = target_dims[:]  # This is kept for the error messages.
 

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -791,7 +791,11 @@ def _match_dimensions(edges, target_dims):
     if len(edges) == 0 and len(target_dims) == 0:
         return _edges
 
-    if len(edges) == 0 or len(target_dims) == 0 or np.prod(e_dims) != np.prod(target_dims):
+    if (
+        len(edges) == 0
+        or len(target_dims) == 0
+        or np.prod(e_dims) != np.prod(target_dims)
+    ):
         raise ValueError(
             "edges are not compatible. The dimensions for edges is "
             + str(e_dims)

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -596,12 +596,12 @@ class Network(qutip.core.data.Data):
 
         Examples
         --------
-        >>>network_dim = [4]
-        >>>target_dims = [2, 2]
-        >>>array = np.random.random(network_dim)
-        >>>node = tn.Node(array)
-        >>>network = Network(node[:], [])
-        >>>network.match_out_dims(target_dims)
+        >>> network_dim = [4]
+        >>> target_dims = [2, 2]
+        >>> array = np.random.random(network_dim)
+        >>> node = tn.Node(array)
+        >>> network = Network(node[:], [])
+        >>> network.match_out_dims(target_dims)
 
         Raises
         ------
@@ -637,12 +637,12 @@ class Network(qutip.core.data.Data):
 
         Examples
         --------
-        >>>network_dim = [4]
-        >>>target_dims = [2, 2]
-        >>>array = np.random.random(network_dim)
-        >>>node = tn.Node(array)
-        >>>network = Network(node[:], [])
-        >>>network.match_out_dims(target_dims)
+        >>> network_dim = [4]
+        >>> target_dims = [2, 2]
+        >>> array = np.random.random(network_dim)
+        >>> node = tn.Node(array)
+        >>> network = Network(node[:], [])
+        >>> network.match_out_dims(target_dims)
 
         Raises
         ------
@@ -768,22 +768,23 @@ def _match_dimensions(edges, target_dims):
 
     Examples
     --------
-    >>>network_dim = [4]
-    >>>target_dims = [2, 2]
-    >>>array = np.random.random(network_dim)
-    >>>node = tn.Node(array)
-    >>>network = Network(node[:], [])
-    >>>_match_dimensions(network.in_edges, target_dims)
+    >>> network_dim = [4]
+    >>> target_dims = [2, 2]
+    >>> array = np.random.random(network_dim)
+    >>> node = tn.Node(array)
+    >>> network = Network(node[:], [])
+    >>> _match_dimensions(network.in_edges, target_dims)
     ValueError
 
     Since only splitting of edges are allowed, the next example will raise a
-    ValueError.
-    >>>network_dim = [2, 2]
-    >>>target_dims = [4]
-    >>>array = np.random.random(network_dim)
-    >>>node = tn.Node(array)
-    >>>network = Network(node[:], [])
-    >>>_match_dimensions(network.in_edges, target_dims)
+    ValueError:
+    
+    >>> network_dim = [2, 2]
+    >>> target_dims = [4]
+    >>> array = np.random.random(network_dim)
+    >>> node = tn.Node(array)
+    >>> network = Network(node[:], [])
+    >>> _match_dimensions(network.in_edges, target_dims)
     ValueError
     """
 
@@ -798,19 +799,11 @@ def _match_dimensions(edges, target_dims):
     if len(edges) == 0 and len(target_dims) == 0:
         return _edges
 
-    if len(edges) == 0 or len(target_dims) == 0:
+    if len(edges) == 0 or len(target_dims) == 0 or np.prod(e_dims) != np.prod(target_dims):
         raise ValueError(
             "edges are not compatible. The dimensions for edges is "
             + str(e_dims)
             + ", whereas the target dimension is"
-            + str(_target_dims)
-        )
-
-    if np.prod(e_dims) != np.prod(target_dims):
-        raise ValueError(
-            "edges are not compatible. The dimensions of edges is "
-            + str(e_dims)
-            + ", whereas the target dimension is "
             + str(_target_dims)
         )
 

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -691,23 +691,27 @@ def _match_dimensions(edges, target_dims):
     Examples
     --------
     >>>network_dim = [4]
-    >>>target_dims = [2,2]
+    >>>target_dims = [2, 2]
     >>>array = np.random.random(network_dim)
-    >>>network = Network.from_2d_array(array)
-    >>>match_dimensions(network.in_edges, target_dims)
+    >>>node = tn.Node(array)
+    >>>network = Network(node[:], [])
+    >>>_match_dimensions(network.in_edges, target_dims)
+    ValueError
 
-    Since only splitting of edges are allowed, the next example ill raise a
-    ValuError.
+    Since only splitting of edges are allowed, the next example will raise a
+    ValueError.
     >>>network_dim = [2, 2]
     >>>target_dims = [4]
     >>>array = np.random.random(network_dim)
-    >>>network = Network.from_2d_array(array)
-    >>>match_dimensions(network.in_edges, target_dims)
+    >>>node = tn.Node(array)
+    >>>network = Network(node[:], [])
+    >>>_match_dimensions(network.in_edges, target_dims)
     ValueError
     """
 
     edges = edges[:]
     target_dims = target_dims[:]
+    _target_dims = target_dims[:] # This is kept for the error messages.
 
     e_dims = [e.dimension for e in edges]
 
@@ -718,18 +722,18 @@ def _match_dimensions(edges, target_dims):
 
     if len(edges) == 0 or len(target_dims) == 0:
         raise ValueError(
-            "edges are not compatible. The dimensions for in_edges is: "
+            "edges are not compatible. The dimensions for edges is "
             + str(e_dims)
-            + " whereas for out_edges is: "
-            + str(target_dims)
+            + ", whereas the target dimension is"
+            + str(_target_dims)
         )
 
-    if np.prod(e_dims) != np.product(target_dims):
+    if np.prod(e_dims) != np.prod(target_dims):
         raise ValueError(
-            "edges are not compatible. The dimensions of in_edges: "
+            "edges are not compatible. The dimensions of edges is "
             + str(e_dims)
-            + " whereas for out_edges: "
-            + str(target_dims)
+            + ", whereas the target dimension is "
+            + str(_target_dims)
         )
 
     edge = edges.pop()
@@ -749,9 +753,9 @@ def _match_dimensions(edges, target_dims):
             if edge.dimension % target_dim != 0:
                 raise ValueError(
                     "edges are not compatible. The dimensions of edges is "
-                    + str(edge.dimension)
-                    + " whereas the target dimension is "
-                    + str(target_dims)
+                    + str(e_dims)
+                    + ", whereas the target dimension is "
+                    + str(_target_dims)
                     + "."
                 )
             else:
@@ -766,9 +770,9 @@ def _match_dimensions(edges, target_dims):
 
             raise ValueError(
                 "edges are not compatible. The dimensions of edges is "
-                + str(edge.dimension)
-                + " whereas the target dimension is "
-                + str(target_dims)
+                + str(e_dims)
+                + ", whereas the target dimension is "
+                + str(_target_dims)
                 + ". The reason for these edges to not be compatible is"
                 + " that only splitting of edges is allowed for this"
                 + " operation but a merge of edges was required."

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -761,7 +761,6 @@ def _match_dimensions(edges, target_dims):
     matches target_dims. Only split of edges are allowed in order to match
     target_dims.
 
-
     Note
     ----
     The modifications to edges are performed in-place, which is why the
@@ -790,7 +789,7 @@ def _match_dimensions(edges, target_dims):
 
     edges = edges[:]
     target_dims = target_dims[:]
-    _target_dims = target_dims[:] # This is kept for the error messages.
+    _target_dims = target_dims[:]  # This is kept for the error messages.
 
     e_dims = [e.dimension for e in edges]
 
@@ -828,7 +827,7 @@ def _match_dimensions(edges, target_dims):
             edge = edges.pop()
             target_dim = target_dims.pop()
 
-        elif edge.dimension > target_dim: # Split edge
+        elif edge.dimension > target_dim:  # Split edge
             if edge.dimension % target_dim != 0:
                 raise ValueError(
                     "edges are not compatible. The dimensions of edges is "
@@ -860,4 +859,3 @@ def _match_dimensions(edges, target_dims):
     new_edges.reverse()
 
     return new_edges
-

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -551,7 +551,7 @@ class Network(qutip.core.data.Data):
         return Network._fast_constructor(out_edges, in_edges, nodes)
 
     def match_out_dims(self, target_dims):
-        """Reshape the nodes by splitting edge dimensions to match
+        """Reshape nodes by splitting edges such that `in_edges` matches
         ``target_dims``. After this function the following will hold:
             ``network.dims[0] == target_dims``
 
@@ -567,13 +567,32 @@ class Network(qutip.core.data.Data):
         Returns
         -------
         Network
+
+        Examples
+        --------
+        >>>network_dim = [4]
+        >>>target_dims = [2, 2]
+        >>>array = np.random.random(network_dim)
+        >>>node = tn.Node(array)
+        >>>network = Network(node[:], [])
+        >>>network.match_out_dims(target_dims)
+
+        Raises
+        ------
+        ValueError
+            If the target_dims is not compatible or if merging of dimensions is
+            necessary to make the edges compatible with the target dimension.
+
+        See also
+        --------
+        match_in_dims
         """
         edges = _match_dimensions(self.out_edges, target_dims)
         self.out_edges = edges
         return self
 
     def match_in_dims(self, target_dims):
-        """Reshape the nodes by splitting edge dimensions to match
+        """Reshape nodes by splitting edges such that `in_edges` matches
         ``target_dims``. After this function the following will hold:
             ``network.dims[1] == target_dims``
 
@@ -589,6 +608,25 @@ class Network(qutip.core.data.Data):
         Returns
         -------
         Network
+
+        Examples
+        --------
+        >>>network_dim = [4]
+        >>>target_dims = [2, 2]
+        >>>array = np.random.random(network_dim)
+        >>>node = tn.Node(array)
+        >>>network = Network(node[:], [])
+        >>>network.match_out_dims(target_dims)
+
+        Raises
+        ------
+        ValueError
+            If the target_dims is not compatible or if merging of dimensions is
+            necessary to make the edges compatible with the target dimension.
+
+        See also
+        --------
+        match_out_dims
         """
         edges = _match_dimensions(self.in_edges, target_dims)
         self.in_edges = edges

--- a/tests/core/data/test_network.py
+++ b/tests/core/data/test_network.py
@@ -361,6 +361,7 @@ def test_from_2d_array(shape, expected_dims):
         ([2, 2], [2, 2]),
         ([2, 4, 2], [2, 2, 2, 2]),
         ([2, 15, 7], [2, 3, 5, 7]),
+        ([30], [2, 3, 5]),
     ],
 )
 class TestMatchDims:
@@ -383,15 +384,17 @@ class TestMatchDims:
         node = random_node(dim_edges)
         network = Network(node[:], [], copy=False)
         new_network = network.match_out_dims(target_dims)
-        assert new_network is network
-        assert network.dims[0] == target_dims
+        assert new_network is not network
+        assert new_network.dims[0] == target_dims
+        assert_almost_equal(new_network.to_array(), network.to_array())
 
     def test_match_in_dims(self, dim_edges, target_dims):
         node = random_node(dim_edges)
         network = Network([], node[:], copy=False)
         new_network = network.match_in_dims(target_dims)
-        assert new_network is network
-        assert network.dims[1] == target_dims
+        assert new_network is not network
+        assert new_network.dims[1] == target_dims
+        assert_almost_equal(new_network.to_array(), network.to_array())
 
 
 @pytest.mark.parametrize(
@@ -400,6 +403,8 @@ class TestMatchDims:
         ([2, 2], [4]),
         ([2, 2], [3]),
         ([2, 3, 5], [2, 5, 3]),
+        ([2, 4, 5], [2, 2, 2, 3]),
+        ([5, 4, 2], [3, 2, 2, 2]),
     ],
 )
 class TestMatchDimsRaise:
@@ -411,20 +416,32 @@ class TestMatchDimsRaise:
     def test_match_dimensions_raises(self, dim_edges, target_dims):
         node = random_node(dim_edges)
         network = Network(node[:], [], copy=False)
+        copy = network.copy()
+
         with pytest.raises(ValueError):
             _match_dimensions(network.out_edges, target_dims)
+
+        np.testing.assert_equal(copy.to_array(), network.to_array())
 
     def test_match_out_dims_raises(self, dim_edges, target_dims):
         node = random_node(dim_edges)
         network = Network(node[:], [], copy=False)
+        copy = network.copy()
+
         with pytest.raises(ValueError):
             network.match_out_dims(target_dims)
+
+        np.testing.assert_equal(copy.to_array(), network.to_array())
 
     def test_match_in_dims_raises(self, dim_edges, target_dims):
         node = random_node(dim_edges)
         network = Network(node[:], [], copy=False)
+        copy = network.copy()
+
         with pytest.raises(ValueError):
             network.match_in_dims(target_dims)
+
+        np.testing.assert_equal(copy.to_array(), network.to_array())
 
 
 class TestMul:

--- a/tests/core/data/test_network.py
+++ b/tests/core/data/test_network.py
@@ -364,8 +364,8 @@ def test_from_2d_array(shape, expected_dims):
     ],
 )
 class TestMatchDims:
-    """This class contians all the tests for the functions that change the
-    dimsnension of a network by splitting edges.
+    """This class contains all the tests for the functions that change the
+    dimensions of a network by splitting edges.
     """
 
     def test_match_dimensions(self, dim_edges, target_dims):
@@ -402,10 +402,10 @@ class TestMatchDims:
         ([2, 3, 5], [2, 5, 3]),
     ],
 )
-class TestMatchDimsRaisise:
-    """This class contians the tests for the functions that change the
-    dimsnension of a network by splitting edges. In particular it ensures that
-    thep proper error is raised.
+class TestMatchDimsRaise:
+    """This class contains the tests for the functions that change the
+    dimensions of a network by splitting edges. In particular it ensures that
+    the correct errors are raised.
     """
 
     def test_match_dimensions_raises(self, dim_edges, target_dims):

--- a/tests/core/data/test_network.py
+++ b/tests/core/data/test_network.py
@@ -373,7 +373,7 @@ class TestMatchDims:
         network = Network(node[:], [], copy=False)
         edges = _match_dimensions(network.out_edges, target_dims)
         assert [e.dimension for e in edges] == target_dims
-        # We do not test for the edges in `node.edges` being properly ordered. 
+        # We do not test for the edges in `node.edges` being properly ordered.
         # This is because (surprisingly) split_edges does not repect the order of
         # edges in a node.
         # For network operations this will not be a problem.


### PR DESCRIPTION
This PR implements two methods, `match_in_dims` and `match_out_dims` that allows splitting edges to match a target dimension. This is primarily meant to be used with `ptrace` as we need to reshape the outer nodes such that the network has the appropriate dimensions.

Note that `_match_edges_by_split` is a very similar function but with different scope. The new `_match_dimensions` is meant to be used with unary operators that required a change in the dimension (ptrace) whereas `_match_edges_by_split` is meant to be used with binary operators (matmul). This is because for  `_match_dimensions` (unary version) we do not allow merging two edge dimension. However, such operation can also be achieved in `_match_edges_by_split` (binary version) by just splitting the edges as two list of edges is available.

The reason to not allow here in `_match_dimensions` to merge edges is because this is a relatively complex operation that will require contracting nodes. I am assuming that it is best to do the contraction of the full network in a single step such that an optimized path is used.