### PR TITLE
Added the tensor_train class.

### DIFF
--- a/src/qutip_tensornetwork/core/data/__init__.py
+++ b/src/qutip_tensornetwork/core/data/__init__.py
@@ -3,3 +3,4 @@ from .convert import *
 from .matmul import *
 from .tensor import *
 from .mul import *
+from .tensor_train import *

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -295,8 +295,9 @@ class Network(qutip.core.data.Data):
             return out.contract(contractor, copy=False)
 
         nodes_dict, edges_dict = tn.copy(self.nodes)
-        nodes = set([contractor(self.nodes, output_edge_order=self.out_edges +
-                               self.in_edges)])
+        nodes = set(
+            [contractor(self.nodes, output_edge_order=self.out_edges + self.in_edges)]
+        )
         self._nodes = nodes
         return self
 
@@ -391,30 +392,30 @@ class Network(qutip.core.data.Data):
 
         if len(shape) == 1:
             node = tn.Node(array)
-            return Network(node[:], [])
+            return cls(node[:], [])
 
         if len(shape) == 0:
             node = tn.Node(array)
-            return Network([], [], [node])
+            return cls([], [], [node])
 
         if array.shape[0] == 1 and array.shape[1] != 1:
             array = array.reshape(array.shape[1])
             node = tn.Node(array)
-            return Network([], node[:])
+            return cls([], node[:])
 
         elif array.shape[0] != 1 and array.shape[1] == 1:
             array = array.reshape(array.shape[0])
             node = tn.Node(array)
-            return Network(node[:], [])
+            return cls(node[:], [])
 
         elif array.shape[0] == 1 and array.shape[1] == 1:
             array = array.reshape(())
             node = tn.Node(array)
-            return Network([], [], nodes=[node])
+            return cls([], [], nodes=[node])
 
         else:
             node = tn.Node(array)
-            return Network(node[0:1], node[1:])
+            return cls(node[0:1], node[1:])
 
     def partial_trace(self, subsystems_to_trace_out):
         """NOT IMPLEMENTED YET.

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -117,7 +117,7 @@ class Network(qutip.core.data.Data):
         # dynamically searching for them when necessary. This is because
         # searching all nodes in a large graph can be quite expensive while
         # keeping track of them with network operations is straightforward.
-        self.nodes = (
+        self._nodes = (
             set(nodes) if nodes else tn.reachable(self.in_edges + self.out_edges)
         )
 
@@ -129,7 +129,7 @@ class Network(qutip.core.data.Data):
 
         if copy:
             node_dict, edge_dict = tn.copy(self.nodes)
-            self.nodes = set(node_dict[n] for n in self.nodes)
+            self._nodes = set(node_dict[n] for n in self.nodes)
             self.in_edges = [edge_dict[e] for e in self.in_edges]
             self.out_edges = [edge_dict[e] for e in self.out_edges]
 
@@ -203,7 +203,7 @@ class Network(qutip.core.data.Data):
         out = cls.__new__(cls)
         out.in_edges = in_edges
         out.out_edges = out_edges
-        out.nodes = nodes
+        out._nodes = nodes
 
         return out
 
@@ -267,7 +267,7 @@ class Network(qutip.core.data.Data):
 
         return Network._fast_constructor(out_edges, in_edges, nodes)
 
-    def contract(self, contractor=greedy, final_edge_order=None):
+    def contract(self, contractor=greedy, copy=True):
         """Return the contracted version of the tensor network.
 
         Parameters
@@ -276,8 +276,6 @@ class Network(qutip.core.data.Data):
             A function that performs the contraction. Defaults to
             ``tensornetwork.contractor.greedy``, which uses the greedy
             algorithm from `opt_einsum` to determine a contraction order.
-
-        final_edge_order: iterable of tensornetwork.Edges
 
         Returns
         -------
@@ -289,19 +287,19 @@ class Network(qutip.core.data.Data):
             tensornetwork.contractor: This module contains other functions that
             can be used instead of ``greedy``.
         """
+        if copy:
+            out = self.copy()
+            return out.contract(contractor, copy=False)
+
         nodes_dict, edges_dict = tn.copy(self.nodes)
+        nodes = set([contractor(self.nodes, output_edge_order=self.out_edges +
+                               self.in_edges)])
+        self._nodes = nodes
+        return self
 
-        in_edges = [edges_dict[e] for e in self.in_edges]
-        out_edges = [edges_dict[e] for e in self.out_edges]
-        nodes = set(nodes_dict[n] for n in self.nodes if n in nodes_dict)
-
-        if final_edge_order is not None:
-            final_edge_order = [edges_dict[e] for e in final_edge_order]
-            nodes = set([contractor(nodes, output_edge_order=final_edge_order)])
-        else:
-            nodes = set([contractor(nodes, ignore_edge_order=True)])
-
-        return Network._fast_constructor(out_edges, in_edges, nodes)
+    @property
+    def nodes(self):
+        return _nodes
 
     def to_array(self, contractor=greedy):
         """Returns a 2D array that represents the contraction of the tensor

--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -277,6 +277,9 @@ class Network(qutip.core.data.Data):
             ``tensornetwork.contractor.greedy``, which uses the greedy
             algorithm from `opt_einsum` to determine a contraction order.
 
+        copy: bool
+            Default True. If False, perform the operation in-place.
+
         Returns
         -------
         Network
@@ -299,7 +302,7 @@ class Network(qutip.core.data.Data):
 
     @property
     def nodes(self):
-        return _nodes
+        return self._nodes
 
     def to_array(self, contractor=greedy):
         """Returns a 2D array that represents the contraction of the tensor
@@ -321,7 +324,7 @@ class Network(qutip.core.data.Data):
             The final tensor representing the operator.
         """
         final_edge_order = self.out_edges + self.in_edges
-        network = self.contract(contractor, final_edge_order=final_edge_order)
+        network = self.contract(contractor)
         nodes = network.nodes
         if len(nodes) != 1:
             raise ValueError(

--- a/src/qutip_tensornetwork/core/data/tensor_train/__init__.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/__init__.py
@@ -1,0 +1,1 @@
+from .tensor_train import *

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -1,0 +1,250 @@
+from qutip_tensornetwork.core.data.network import Network, _match_edges_by_split
+import tensornetwork as tn
+
+class FiniteTT(Network):
+    """Represent finite tensor-trains. This can be either MPS or MPO. A
+    schematic representation of such tensor trains are:
+        |   |   |
+        * - * - *
+        |   |   |
+    where "-" represents an edge and "*" a node. The above graph represents an
+    MPO but MPS can also be represented with this class. The dangling edges
+    represent the ``in_edges`` and ``out_edges`` (which correspond to rows and
+    columns of a matrix when the network is contracted into a 2D array). The
+    bonds connecting the nodes can be accessed with ``bond_edges``. Nodes can
+    also be accessed in a shorted list format using ``node_list``.
+
+    Notes
+    -----
+    Nodes in this class have been named from 0 to L, with L the number of
+    nodes,  as they can be sorted (from left to right). The axis of each node
+    have also been named for easy access. These are named as: {"in", "out",
+    "rbond", "lbond"}.
+
+    Parameters
+    ----------
+    out_edges: List of Edges
+        The edges of the network to be used as the output edges.
+
+    in_edges: List of Edges
+        The edges of the network to be used as the input edges.
+
+    nodes: None or List of Nodes
+        Nodes of the network. If None, the nodes are obtained
+        by finding all the nodes that belong to the graphs that include
+        ``in_edges`` and ``out_edges``.
+
+    copy: bool, default True
+        Whether to copy all the ``Nodes``/``Edges`` involved in the
+        network.
+
+    Attributes
+    ----------
+    nodes : set of Nodes
+        Nodes that belong to the Network. These can either be reachable from
+        in_edges and out_edges or scalar nodes, in which case they have no
+        edges.
+
+    nodes_list: List of Nodes
+        Nodes of the tensor-train sorted from left to right.
+
+
+    out_edges : list of Edges
+        List of ``Edges`` to be used. When the network is considered as a
+        matrix, these edges represent the rows.
+
+    in_edges : list of Edges
+        List of ``Edges`` to be used. When the network is considered as a
+        matrix, these edges represent the columns.
+
+    bond_edges: List of Edges
+        The edges between the nodes of the tensor-train. These are sorted from
+        left to right (i.e. ``nodes_list[i]["rbond"] == bond_edges[i]``).
+
+    dims : list of int
+        Dimension of the system as a list of lists. dims[0] represents the
+        out dimensions whereas dims[1] represents the in dimension.
+
+    shape : tuple of int
+        Shape that the matrix would have if the network is represented with a
+        matrix.
+    """
+
+    def __init__(self, out_edges, in_edges, nodes=None, copy=True):
+        out_dims = [e for e in out_edges]
+        in_dims = [e for e in in_edges]
+        if (in_dims != out_dims and in_edges and out_edges):
+            raise NotImplementedError(" At this moment this class can"
+                                      " only represent square matrices, kets"
+                                      " and bras.")
+        super().__init__(out_edges, in_edges, nodes, copy)
+        _network_to_tt(self, copy=False)
+
+    @property
+    def node_list(self):
+        """Return the nodes as an ordered list. The order goes from left to
+        right in the tensor-train."""
+        if self.in_edges:
+            return [edge.node1 for edge in self.in_edges]
+        else:
+            return [edge.node1 for edge in self.out_edges]
+
+    @property
+    def bond_dimension(self):
+        """Return a list that represent the dimension of each bond edges from
+        left to right."""
+        return [e.dimension for e in self.bond_edges]
+
+    @classmethod
+    def from_node_list(cls, nodes):
+        """Create a tensor-train from a list of nodes.
+
+        By default we assume that the input is a ket (MPS) if the first node has
+        two dimension and we assume it is a square operator (MPO) if it has
+        three dimensions.
+
+        Parameters
+        ----------
+        nodes: List of Node
+            The nodes are assumed to have the foolowing ranks (MPS):
+                nodes[0].shape = (out_dim, bond_dim)
+                nodes[1:-1].shape = (out_dim, bond_dim, bond_dim)
+                nodes[-1].shape = (out_dim, bond_dim)
+            or (MPO):
+                nodes[0].shape = (out_dim, in_dim, bond_dim)
+                nodes[1:-1].shape = (out_dim, in_dim, bond_dim, bond_dim)
+                nodes[-1].shape = (out_dim, in_dim, bond_dim)
+        """
+        nodes = [tn.Node(node) for node in nodes]
+
+        is_ket = len(nodes[0].shape) == 2
+        _check_shape(nodes)
+
+        for i, node in enumerate(nodes):
+            node.name = f"node_{i}"
+
+        if is_ket:
+            nodes[0].add_axis_names(["out", "rbond"])
+            nodes[-1].add_axis_names(["out", "lbond"])
+            for node in nodes[1:-1]:
+                node.add_axis_names(["out", "lbond", "rbond"])
+        else:
+            nodes[0].add_axis_names(["out", "in", "rbond"])
+            nodes[-1].add_axis_names(["out", "in", "lbond"])
+            for node in nodes[1:-1]:
+                node.add_axis_names(["out", "in", "lbond", "rbond"])
+
+        for i in range(len(nodes)-1):
+            bond_edge = nodes[i]["rbond"] ^ nodes[i+1]["lbond"]
+
+        out_edges = [node["out"] for node in nodes]
+        in_edges = [] if is_ket else [node["in"] for node in nodes]
+
+        network = cls._fast_constructor(out_edges, in_edges, nodes)
+        return network
+
+    @property
+    def bond_edges(self):
+        """Returns the bond edges as a list sorted from left to right."""
+        return [node["rbond"] for node in self.nodes_as_list[:-1]]
+
+def _check_shape(nodes):
+    """Check that the nodes have the appropiate shape for the `from_node_list`
+    method."""
+    if len(node[0].shape) != 2 or len(node[0].shape) != 3:
+        raise ValueError(" the shape of the input nodes is not correct. The"
+                         f" first node has rank {len(node[0].shape)} but can"
+                         " only be 2 or 3.")
+
+    for i, node in enumerate(nodes[1:-1], start=1):
+        if len(node.shape) != 1 + len(nodes[0].shape)
+            raise ValueError(" the shape of the {i}-th node is not correct. It"
+                             f" has rank {len(node.shape)} but was expecting"
+                             f" {len(nodes[0].shape) + 1}.")
+        # Checking bond_dimension is not sctrictly necessary but we do it to
+        # raise a clearer error message.
+        if node.shape[-2] != previous_lbond_dim:
+            raise ValueError(f" the bond shape between the {i-1}-th and {i}-th
+                             f" nodes is different ({previous_lbond_dim} and"
+                             f" {node.shape[-2]} respectively).")
+        previous_lbond_dim = nodes.shape[-1]
+
+    if len(nodes[-1].shape) != len(nodes[0].shape)
+        raise ValueError(" the shape of the last node is not correct. It"
+                         f" has rank {len(nodes[-1].shape)} but was expecting"
+                         f" {len(nodes[0].shape)}.")
+
+    if nodes[-1].shape[-1] != previous_lbond_dim:
+        raise ValueError(f" the bond shape between the last and the {i}-th node is"
+                         f" different ({previous_lbond_dim} and"
+                         f" {nodes[-1].shape[-1]} respectively).")
+
+def network_to_tt(network, copy=False):
+    """This function transforms an arbitrary network into a tensor train. This
+    is done by first contrancting the whole network into a single tensor an
+    then spliting it into a tensor-train by repeatedly appliying an svd
+    tranformation to the nodes. No truncation is done by this function. Hence
+    the output tensor-train represents exactly the input network.
+
+    For a more detailed explanation of the algorithm see [1]_.
+
+    Paramaters
+    ----------
+    network : Network
+
+    copy: bool
+        If False, the operation is performed in-place.
+
+    References
+    ----------
+    .. [1] Paeckel, S., Köhler, T., Swoboda, A., Manmana, S. R., Schollwöck,
+    U., & Hubig, C. (2019). Time-evolution methods for matrix-product states.
+    Annals of Physics, 411, 167998.
+    """
+    if (network.dims[0]!= network.dims[1] and network.in_edges and
+        network.out_edges):
+        raise NotImplementedError(" At this moment this class can"
+                                  " only represent square matrices, kets"
+                                  " and bras.")
+    network = network.contract(copy)
+
+    max_range = max(len(network.in_edges), len(network.out_edges))
+    if network.in_edges:
+        in_edges = [[e] for e in network.in_edges]
+    else:
+        in_edges = [[]*max_range]
+
+    if network.out_edges:
+        out_edges = [[e] for e in network.in_edges]
+    else:
+        out_edges = [[]*max_range]
+
+    left_edges = [ e_out + e_in for e_out, e_in in zip(out_edges, in_edges)]
+    axes_names = ["out"]*len(self.out_edges) + ["in"]*len(self.in_edges)
+
+    nodes = []
+    lbond = []
+    for i in range(max_range-1):
+        left_edges = [network.out_edges[i]] if network.out_edges else []
+        left_edges += [network.in_edges[i]] if network.in_edges else []
+        left_edges += lbond
+
+        right_edges = network.in_edges[i+1:] if network.in_edges else []
+        right_edges += network.out_edges[i+1:] if network.out_edges else []
+        node = left_edges[0].node1
+        lnode, rnode, _ = tn.split_node(node, left_edges, right_edges)
+
+        rbond = [rnode[0]]
+        lnode.name = f"node_{i}"
+        lnode.reorder_edges(left_edges + rbond)
+        lnode.add_axis_names(axes_names + ["lbond"]*len(lbond) + ["rbond"])
+        nodes.append(lnode)
+        bond_edge = new_bond_edge
+
+    rnode.name = f"node_{max_range}"
+    lnode.reorder_edges(right_edges + rbond)
+    lnode.add_axis_names(axes_names + ["lbond"])
+    nodes.append(rnode)
+
+    network._nodes = set(nodes)
+    return network

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -166,14 +166,13 @@ class FiniteTT(Network):
 
         For a more detailed explanation of the algorithm see [1]_.
 
-        Note that this method was created to be used in the init method of
-        the FiniteTT class. It performs an in-place modification of the nodes.
+        Note that this method was created to be used in the init method of the
+        FiniteTT class. It performs an in-place modification of the nodes.
 
         References
-        ----------
-        .. [1] Paeckel, S., Köhler, T., Swoboda, A., Manmana, S. R., Schollwöck,
-        U., & Hubig, C. (2019). Time-evolution methods for matrix-product states.
-        Annals of Physics, 411, 167998.
+        ---------- .. [1] Paeckel, S., Köhler, T., Swoboda, A., Manmana, S. R.,
+        Schollwöck, U., & Hubig, C. (2019). Time-evolution methods for
+        matrix-product states.  Annals of Physics, 411, 167998.
         """
         self.contract(copy=False)
 

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -149,7 +149,7 @@ class FiniteTT(Network):
         return [node["rbond"] for node in self.nodes_as_list[:-1]]
 
 def _check_shape(nodes):
-    """Check that the nodes have the appropiate shape for the `from_node_list`
+    """Check that the nodes have the appropriate shape for the `from_node_list`
     method."""
     if len(node[0].shape) != 2 or len(node[0].shape) != 3:
         raise ValueError(" the shape of the input nodes is not correct. The"
@@ -181,14 +181,14 @@ def _check_shape(nodes):
 
 def network_to_tt(network, copy=False):
     """This function transforms an arbitrary network into a tensor train. This
-    is done by first contrancting the whole network into a single tensor an
-    then spliting it into a tensor-train by repeatedly appliying an svd
-    tranformation to the nodes. No truncation is done by this function. Hence
+    is done by first contracting the whole network into a single tensor an
+    then splitting it into a tensor-train by repeatedly applying an svd
+    transformation to the nodes. No truncation is done by this function. Hence
     the output tensor-train represents exactly the input network.
 
     For a more detailed explanation of the algorithm see [1]_.
 
-    Paramaters
+    Parameters
     ----------
     network : Network
 
@@ -203,7 +203,7 @@ def network_to_tt(network, copy=False):
     """
     if (network.dims[0]!= network.dims[1] and network.in_edges and
         network.out_edges):
-        raise NotImplementedError(" At this moment this class can"
+        raise NotImplementedError(" At this moment the FiniteTT class can"
                                   " only represent square matrices, kets"
                                   " and bras.")
     network = network.contract(copy)

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -2,7 +2,9 @@ from qutip_tensornetwork.core.data.network import Network, _match_edges_by_split
 import tensornetwork as tn
 from itertools import chain
 
-__all__ = ["FiniteTT", ]
+__all__ = [
+    "FiniteTT",
+]
 
 
 class FiniteTT(Network):
@@ -197,8 +199,8 @@ class FiniteTT(Network):
             left_edges += in_edges[i]
             left_edges += lbond
 
-            right_edges = out_edges[i + 1:]
-            right_edges += in_edges[i + 1:]
+            right_edges = out_edges[i + 1 :]
+            right_edges += in_edges[i + 1 :]
             # We flatten the right edges as it is a list of lists
             right_edges = list(chain(*right_edges))
 
@@ -234,6 +236,7 @@ class FiniteTT(Network):
             nodes.append(rnode)
 
         self._nodes = set(nodes)
+
 
 def _check_shape(nodes):
     """Check that the nodes have the appropriate shape for the `from_node_list`

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -75,8 +75,6 @@ class FiniteTT(Network):
     """
 
     def __init__(self, out_edges, in_edges, nodes=None, copy=True):
-        if not copy:
-            return NotImplementedError()
         out_dims = [e.dimension for e in out_edges]
         in_dims = [e.dimension for e in in_edges]
         if in_dims != out_dims and in_edges and out_edges:
@@ -85,10 +83,9 @@ class FiniteTT(Network):
                 " only represent square matrices, kets"
                 " and bras."
             )
-        if copy:
-            super().__init__(out_edges, in_edges, nodes, copy)
-            self._to_tt_format()
-            print(self.nodes)
+
+        super().__init__(out_edges, in_edges, nodes, copy)
+        self._to_tt_format()
 
     @property
     def train_nodes(self):

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -232,12 +232,12 @@ def network_to_tt(network, copy=True):
     if network.in_edges:
         in_edges = [[e] for e in network.in_edges]
     else:
-        in_edges = [[] * n_nodes]
+        in_edges = [[] for _ in range(n_nodes)]
 
     if network.out_edges:
-        out_edges = [[e] for e in network.in_edges]
+        out_edges = [[e] for e in network.out_edges]
     else:
-        out_edges = [[] * n_nodes]
+        out_edges = [[] for _ in range(n_nodes)]
 
     axes_names = ["out"] if network.out_edges else []
     axes_names += ["in"] if network.in_edges else []
@@ -270,7 +270,7 @@ def network_to_tt(network, copy=True):
         right_edges = [network.out_edges[0]] if network.out_edges else []
         right_edges += [network.in_edges[0]] if network.in_edges else []
         node = right_edges[0].node1
-        node.name = f"node_{n_nodes-1}"
+        node.name = f"node_0"
         node.reorder_edges(right_edges)
         node.add_axis_names(axes_names)
         nodes.append(node)

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -89,9 +89,9 @@ class FiniteTT(Network):
             print(self.nodes)
 
     @property
-    def node_list(self):
-        """Return the nodes as an ordered list. The order goes from left to
-        right in the tensor-train."""
+    def train_nodes(self):
+        """Return the nodes of the train as an ordered list. The order goes
+        from left to right in the tensor-train."""
         if self.in_edges:
             return [edge.node1 for edge in self.in_edges]
         else:
@@ -154,7 +154,7 @@ class FiniteTT(Network):
     @property
     def bond_edges(self):
         """Returns the bond edges as a list sorted from left to right."""
-        return [node["rbond"] for node in self.node_list[:-1]]
+        return [node["rbond"] for node in self.train_nodes[:-1]]
 
     def _to_tt_format(self):
         """This function is used to transform an arbitrary network into a

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -50,8 +50,6 @@ class FiniteTT(Network):
 
     nodes_list: List of Nodes
         Nodes of the tensor-train sorted from left to right.
-
-
     out_edges : list of Edges
         List of ``Edges`` to be used. When the network is considered as a
         matrix, these edges represent the rows.
@@ -74,7 +72,7 @@ class FiniteTT(Network):
     """
 
     def __init__(self, out_edges, in_edges, nodes=None, copy=True):
-        if copy == False:
+        if not copy:
             raise NotImplementedError()
         out_dims = [e.dimension for e in out_edges]
         in_dims = [e.dimension for e in in_edges]
@@ -203,7 +201,7 @@ def _check_shape(nodes):
 def network_to_tt(network, copy=True):
     """This function transforms an arbitrary network into a tensor train. This
     is done by first contracting the whole network into a single tensor an
-    then splitting it into a tensor-train by repeatedly applying an svd
+    then splitting it into a tensor-train by repeatedly applying an SVD
     transformation to the nodes. No truncation is done by this function. Hence
     the output tensor-train represents exactly the input network.
 
@@ -214,7 +212,7 @@ def network_to_tt(network, copy=True):
     network : Network
 
     copy: bool
-        If False, the operation is performed in-place.
+        If False, the operation is performed in-place. Default: True.
 
     References
     ----------

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -167,14 +167,7 @@ class FiniteTT(Network):
         For a more detailed explanation of the algorithm see [1]_.
 
         Note that this method was created to be used in the init method of
-        the FiniteTT class.
-
-        Parameters
-        ----------
-        network : Network
-
-        copy: bool
-            If False, the operation is performed in-place. Default: True.
+        the FiniteTT class. It performs an in-place modification of the nodes.
 
         References
         ----------

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -104,7 +104,7 @@ class FiniteTT(Network):
         return [e.dimension for e in self.bond_edges]
 
     @classmethod
-    def from_node_list(cls, nodes):
+    def from_nodes(cls, nodes):
         """Create a tensor-train from a list of nodes.
 
         By default we assume that the input is a ket (MPS) if the first node has
@@ -114,7 +114,7 @@ class FiniteTT(Network):
         Parameters
         ----------
         nodes: List of Node
-            The nodes are assumed to have the foolowing ranks (MPS):
+            The nodes are assumed to have the following ranks (MPS):
                 nodes[0].shape = (out_dim, bond_dim)
                 nodes[1:-1].shape = (out_dim, bond_dim, bond_dim)
                 nodes[-1].shape = (out_dim, bond_dim)

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -21,7 +21,7 @@ class FiniteTT(Network):
     Notes
     -----
     Nodes in this class have been named from 0 to L, with L the number of
-    nodes,  as they can be sorted (from left to right). The axis of each node
+    nodes, as they can be sorted (from left to right). The axes of each node
     have also been named for easy access. These are named as: {"in", "out",
     "rbond", "lbond"}.
 

--- a/tests/core/data/test_network.py
+++ b/tests/core/data/test_network.py
@@ -200,23 +200,25 @@ class TestContract:
 
         network = Network([node2[0]], [node2[1]], [node1, node2])
         result = network.contract()
+        assert result is not network
         result = result.nodes.pop().tensor
 
         expect = (node1 @ node2).tensor
         np.testing.assert_allclose(result, expect)
 
-    def test_final_edge_order(self):
+    def test_final_copy(self):
         node1 = random_node((2,))
         node2 = random_node((2, 2, 2))
         node1[0] ^ node2[2]
 
         network = Network([node2[0]], [node2[1]], [node1, node2])
         # We transpose the final result by changing the final_edge_order
-        result = network.contract(final_edge_order=network.in_edges + network.out_edges)
+        result = network.contract(copy=False)
+        assert result is network
         result = result.nodes.pop().tensor
 
         expect = (node1 @ node2).tensor
-        np.testing.assert_allclose(result, expect.T)
+        np.testing.assert_allclose(result, expect)
 
 
 def test_to_array():

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -107,7 +107,7 @@ class TestInit:
         assert len(tt.bond_edges) == 0
         np.testing.assert_allclose(node.tensor, tt.to_array())
 
-    def test_empty_rises(self):
+    def test_empty_raises(self):
         with pytest.raises(ValueError) as e:
             network = FiniteTT([], [], nodes=[])
 
@@ -233,7 +233,7 @@ class TestFrom_node_list:
         ((), (2,)),
     ],
 )
-def tets_network_to_tt(in_shape, out_shape):
+def test_network_to_tt(in_shape, out_shape):
     in_node = random_node(in_shape)
     out_node = random_node(out_shape)
     network = Network(out_node[:], in_node[:])

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -124,7 +124,7 @@ class TestFrom_node_list:
         list_tensors += [np.random.random((d, chi, chi)) for _ in range(n - 2)]
         list_tensors += [np.random.random((d, chi))]
 
-        tt = FiniteTT.from_node_list(list_tensors)
+        tt = FiniteTT.from_nodes(list_tensors)
 
         assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == 0
@@ -147,7 +147,7 @@ class TestFrom_node_list:
         list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
         list_tensors += [np.random.random((d, d, chi))]
 
-        tt = FiniteTT.from_node_list(list_tensors)
+        tt = FiniteTT.from_nodes(list_tensors)
 
         assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == n
@@ -171,7 +171,7 @@ class TestFrom_node_list:
         list_tensors += [np.random.random((d, d, chi))]
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
-        tt = FiniteTT.from_node_list(list_tensors)
+        tt = FiniteTT.from_nodes(list_tensors)
 
         assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == n
@@ -196,7 +196,7 @@ class TestFrom_node_list:
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
         with pytest.raises(ValueError):
-            FiniteTT.from_node_list(list_tensors)
+            FiniteTT.from_nodes(list_tensors)
 
     def test_incorrect_shape_raises(self, n):
         d = 3
@@ -207,7 +207,7 @@ class TestFrom_node_list:
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
         with pytest.raises(ValueError):
-            FiniteTT.from_node_list(list_tensors)
+            FiniteTT.from_nodes(list_tensors)
 
         if n > 2:
             list_tensors = [np.random.random((d, d, chi))]
@@ -218,7 +218,7 @@ class TestFrom_node_list:
             list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
             with pytest.raises(ValueError):
-                FiniteTT.from_node_list(list_tensors)
+                FiniteTT.from_nodes(list_tensors)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -250,3 +250,28 @@ def tets_network_to_tt(in_shape, out_shape):
     assert_nodes_name(tt)
     assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
     assert_almost_equal(network.to_array(), tt.to_array())
+
+@pytest.mark.parametrize(
+    "shape, expected_dims",
+    [
+        ((2, 2), [[2], [2]]),
+        ((2, 1), [[2], []]),
+        ((1, 2), [[], [2]]),
+        ((2), [[2], []]),
+        ((), [[], []]),
+    ],
+)
+def test_from_2d_array(shape, expected_dims):
+    array = np.random.random(shape)
+    tt = FiniteTT.from_2d_array(array)
+
+    assert isinstance(tt, FiniteTT)
+    assert len(tt.node_list) == (1 if shape else 0)
+    assert len(tt.bond_edges) == 0
+    assert tt.dims == expected_dims
+    assert_in_edges_name(tt)
+    assert_out_edges_name(tt)
+    assert_bond_edges_name(tt)
+    assert_nodes_name(tt)
+    assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+    np.testing.assert_allclose(array, tt.to_array().reshape(shape))

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -12,24 +12,24 @@ import tensornetwork as tn
 
 def assert_nodes_name(tt):
     """Assert if nodes are not named correctly."""
-    for i, node in enumerate(tt.node_list):
+    for i, node in enumerate(tt.train_nodes):
         assert node.name == f"node_{i}"
 
 
 def assert_in_edges_name(tt):
     for i, edge in enumerate(tt.in_edges):
-        assert tt.node_list[i]["in"] is edge
+        assert tt.train_nodes[i]["in"] is edge
 
 
 def assert_out_edges_name(tt):
     for i, edge in enumerate(tt.out_edges):
-        assert tt.node_list[i]["out"] is edge
+        assert tt.train_nodes[i]["out"] is edge
 
 
 def assert_bond_edges_name(tt):
     for i, edge in enumerate(tt.bond_edges):
-        assert tt.node_list[i]["rbond"] is edge
-        assert tt.node_list[i + 1]["lbond"] is edge
+        assert tt.train_nodes[i]["rbond"] is edge
+        assert tt.train_nodes[i + 1]["lbond"] is edge
 
 
 class TestInit:
@@ -51,11 +51,11 @@ class TestInit:
         tt = FiniteTT(out_node[:], in_node[:])
         network = Network(out_node[:], in_node[:])
 
-        assert len(tt.node_list) == max(len(in_shape), len(out_shape))
+        assert len(tt.train_nodes) == max(len(in_shape), len(out_shape))
         assert len(tt.in_edges) == len(in_shape)
         assert len(tt.out_edges) == len(out_shape)
         assert len(tt.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
-        assert set(tt.nodes) == set(tt.node_list)
+        assert set(tt.nodes) == set(tt.train_nodes)
         assert_in_edges_name(tt)
         assert_out_edges_name(tt)
         assert_bond_edges_name(tt)
@@ -101,7 +101,7 @@ class TestInit:
         node = random_node(())
         tt = FiniteTT([], [], nodes=[node])
         assert len(tt.nodes) == 1
-        assert len(tt.node_list) == 0
+        assert len(tt.train_nodes) == 0
         assert len(tt.in_edges) == 0
         assert len(tt.out_edges) == 0
         assert len(tt.bond_edges) == 0
@@ -126,18 +126,18 @@ class TestFrom_node_list:
 
         tt = FiniteTT.from_node_list(list_tensors)
 
-        assert len(tt.node_list) == n
+        assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == 0
         assert len(tt.out_edges) == n
         assert len(tt.bond_edges) == n - 1
-        assert set(tt.nodes) == set(tt.node_list)
+        assert set(tt.nodes) == set(tt.train_nodes)
         assert_in_edges_name(tt)
         assert_out_edges_name(tt)
         assert_bond_edges_name(tt)
         assert_nodes_name(tt)
         assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
 
-        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+        for node_actual, node_desired in zip(tt.train_nodes, list_tensors):
             assert (node_actual.tensor == node_desired).all()
 
     def test_op(self, n):
@@ -149,18 +149,18 @@ class TestFrom_node_list:
 
         tt = FiniteTT.from_node_list(list_tensors)
 
-        assert len(tt.node_list) == n
+        assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == n
         assert len(tt.out_edges) == n
         assert len(tt.bond_edges) == n - 1
-        assert set(tt.nodes) == set(tt.node_list)
+        assert set(tt.nodes) == set(tt.train_nodes)
         assert_in_edges_name(tt)
         assert_out_edges_name(tt)
         assert_bond_edges_name(tt)
         assert_nodes_name(tt)
         assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
 
-        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+        for node_actual, node_desired in zip(tt.train_nodes, list_tensors):
             assert (node_actual.tensor == node_desired).all()
 
     def test_node(self, n):
@@ -173,18 +173,18 @@ class TestFrom_node_list:
 
         tt = FiniteTT.from_node_list(list_tensors)
 
-        assert len(tt.node_list) == n
+        assert len(tt.train_nodes) == n
         assert len(tt.in_edges) == n
         assert len(tt.out_edges) == n
         assert len(tt.bond_edges) == n - 1
-        assert set(tt.nodes) == set(tt.node_list)
+        assert set(tt.nodes) == set(tt.train_nodes)
         assert_in_edges_name(tt)
         assert_out_edges_name(tt)
         assert_bond_edges_name(tt)
         assert_nodes_name(tt)
         assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
 
-        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+        for node_actual, node_desired in zip(tt.train_nodes, list_tensors):
             assert (node_actual.tensor == node_desired.tensor).all()
 
     def test_incorrect_bond_dim_raises(self, n):
@@ -236,7 +236,7 @@ def test_from_2d_array(shape, expected_dims):
     tt = FiniteTT.from_2d_array(array)
 
     assert isinstance(tt, FiniteTT)
-    assert len(tt.node_list) == (1 if shape else 0)
+    assert len(tt.train_nodes) == (1 if shape else 0)
     assert len(tt.bond_edges) == 0
     assert tt.dims == expected_dims
     assert_in_edges_name(tt)

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -251,6 +251,7 @@ def tets_network_to_tt(in_shape, out_shape):
     assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
     assert_almost_equal(network.to_array(), tt.to_array())
 
+
 @pytest.mark.parametrize(
     "shape, expected_dims",
     [

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -1,0 +1,252 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+import pytest
+
+from qutip.core import data
+from qutip.core.data import dense
+from qutip_tensornetwork.core.data import Network, FiniteTT, network_to_tt
+from qutip_tensornetwork.testing import assert_network_close
+from .conftest import random_node, random_complex_network, random_one_node_network
+import tensornetwork as tn
+
+
+def assert_nodes_name(tt):
+    """Assert if nodes are not named correctly."""
+    for i, node in enumerate(tt.node_list):
+        assert node.name == f"node_{i}"
+
+
+def assert_in_edges_name(tt):
+    for i, edge in enumerate(tt.in_edges):
+        assert tt.node_list[i]["in"] is edge
+
+
+def assert_out_edges_name(tt):
+    for i, edge in enumerate(tt.out_edges):
+        assert tt.node_list[i]["out"] is edge
+
+
+def assert_bond_edges_name(tt):
+    for i, edge in enumerate(tt.bond_edges):
+        assert tt.node_list[i]["rbond"] is edge
+        assert tt.node_list[i + 1]["lbond"] is edge
+
+
+class TestInit:
+    @pytest.mark.parametrize(
+        "in_shape, out_shape",
+        [
+            ((2, 2, 2), (2, 2, 2)),
+            ((2, 2), (2, 2)),
+            ((2,), (2,)),
+            ((2, 2, 2), ()),
+            ((2,), ()),
+            ((), (2, 2, 2)),
+            ((), (2,)),
+        ],
+    )
+    def test_init_default_args(self, in_shape, out_shape):
+        in_node = random_node(in_shape)
+        out_node = random_node(out_shape)
+        tt = FiniteTT(out_node[:], in_node[:])
+        network = Network(out_node[:], in_node[:])
+
+        assert len(tt.node_list) == max(len(in_shape), len(out_shape))
+        assert len(tt.in_edges) == len(in_shape)
+        assert len(tt.out_edges) == len(out_shape)
+        assert len(tt.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
+        assert set(tt.nodes) == set(tt.node_list)
+        assert_in_edges_name(tt)
+        assert_out_edges_name(tt)
+        assert_bond_edges_name(tt)
+        assert_nodes_name(tt)
+        assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+        assert_almost_equal(network.to_array(), tt.to_array())
+
+    def test_init_raise_if_edges_not_unique(self):
+        """in_edges and out_edges must be unique."""
+        node = random_node((2, 2))
+        with pytest.raises(ValueError):
+            tt = FiniteTT([node[0]], [node[0]])
+
+    def test_non_dangling_in_or_out_raises(self):
+        """Input edges for in_edges and out_edges must be dangling."""
+        node = random_node((2,))
+        node2 = random_node((2,))
+        node[0] ^ node2[0]
+
+        with pytest.raises(ValueError):
+            tt = FiniteTT([node[0]], [])
+
+        with pytest.raises(ValueError):
+            tt = FiniteTT([], [node[0]])
+
+    def test_nodes_dont_include_edges_raises(self):
+        """Included nodes do not have the passed in_edges or out_edges."""
+        node = random_node((2, 2))
+        node2 = random_node((2, 2))
+        with pytest.raises(ValueError):
+            tt = FiniteTT(node[0:1], node[1:], nodes=[node2])
+
+    def test_non_in_out_edges_dangling_raises(self):
+        """Included nodes can not have dangling edges that are not in_edges or
+        out_edges
+        """
+        node = random_node((2, 2, 2))
+        with pytest.raises(ValueError):
+            tt = FiniteTT([node[0]], [node[1]])
+
+    def test_scalar_network(self):
+        """Test that networks that contains only a scalar node can be created."""
+        node = random_node(())
+        tt = FiniteTT([], [], nodes=[node])
+        assert len(tt.nodes) == 1
+        assert len(tt.node_list) == 0
+        assert len(tt.in_edges) == 0
+        assert len(tt.out_edges) == 0
+        assert len(tt.bond_edges) == 0
+        np.testing.assert_allclose(node.tensor, tt.to_array())
+
+    def test_empty_rises(self):
+        with pytest.raises(ValueError) as e:
+            network = FiniteTT([], [], nodes=[])
+
+        with pytest.raises(ValueError) as e:
+            network = FiniteTT([], [], nodes=None)
+
+
+@pytest.mark.parametrize("n", [2, 3, 4])
+class TestFrom_node_list:
+    def test_ket(self, n):
+        d = 3
+        chi = 10
+        list_tensors = [np.random.random((d, chi))]
+        list_tensors += [np.random.random((d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [np.random.random((d, chi))]
+
+        tt = FiniteTT.from_node_list(list_tensors)
+
+        assert len(tt.node_list) == n
+        assert len(tt.in_edges) == 0
+        assert len(tt.out_edges) == n
+        assert len(tt.bond_edges) == n - 1
+        assert set(tt.nodes) == set(tt.node_list)
+        assert_in_edges_name(tt)
+        assert_out_edges_name(tt)
+        assert_bond_edges_name(tt)
+        assert_nodes_name(tt)
+        assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+
+        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+            assert (node_actual.tensor == node_desired).all()
+
+    def test_op(self, n):
+        d = 3
+        chi = 10
+        list_tensors = [np.random.random((d, d, chi))]
+        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [np.random.random((d, d, chi))]
+
+        tt = FiniteTT.from_node_list(list_tensors)
+
+        assert len(tt.node_list) == n
+        assert len(tt.in_edges) == n
+        assert len(tt.out_edges) == n
+        assert len(tt.bond_edges) == n - 1
+        assert set(tt.nodes) == set(tt.node_list)
+        assert_in_edges_name(tt)
+        assert_out_edges_name(tt)
+        assert_bond_edges_name(tt)
+        assert_nodes_name(tt)
+        assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+
+        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+            assert (node_actual.tensor == node_desired).all()
+
+    def test_node(self, n):
+        d = 3
+        chi = 10
+        list_tensors = [np.random.random((d, d, chi))]
+        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [tn.Node(tensor) for tensor in list_tensors]
+
+        tt = FiniteTT.from_node_list(list_tensors)
+
+        assert len(tt.node_list) == n
+        assert len(tt.in_edges) == n
+        assert len(tt.out_edges) == n
+        assert len(tt.bond_edges) == n - 1
+        assert set(tt.nodes) == set(tt.node_list)
+        assert_in_edges_name(tt)
+        assert_out_edges_name(tt)
+        assert_bond_edges_name(tt)
+        assert_nodes_name(tt)
+        assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+
+        for node_actual, node_desired in zip(tt.node_list, list_tensors):
+            assert (node_actual.tensor == node_desired.tensor).all()
+
+    def test_incorrect_bond_dim_raises(self, n):
+        d = 3
+        chi = 10
+        list_tensors = [np.random.random((d, d, chi + 1))]
+        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [tn.Node(tensor) for tensor in list_tensors]
+
+        with pytest.raises(ValueError):
+            FiniteTT.from_node_list(list_tensors)
+
+    def test_incorrect_shape_raises(self, n):
+        d = 3
+        chi = 10
+        list_tensors = [np.random.random((d, d, chi, chi))]
+        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [tn.Node(tensor) for tensor in list_tensors]
+
+        with pytest.raises(ValueError):
+            FiniteTT.from_node_list(list_tensors)
+
+        if n > 2:
+            list_tensors = [np.random.random((d, d, chi))]
+            list_tensors += [
+                np.random.random((d, d, chi, chi, 10)) for _ in range(n - 2)
+            ]
+            list_tensors += [np.random.random((d, d, chi))]
+            list_tensors = [tn.Node(tensor) for tensor in list_tensors]
+
+            with pytest.raises(ValueError):
+                FiniteTT.from_node_list(list_tensors)
+
+
+@pytest.mark.parametrize(
+    "in_shape, out_shape",
+    [
+        ((2, 2, 2), (2, 2, 2)),
+        ((2, 2), (2, 2)),
+        ((2,), (2,)),
+        ((2, 2, 2), ()),
+        ((2,), ()),
+        ((), (2, 2, 2)),
+        ((), (2,)),
+    ],
+)
+def tets_network_to_tt(in_shape, out_shape):
+    in_node = random_node(in_shape)
+    out_node = random_node(out_shape)
+    network = Network(out_node[:], in_node[:])
+    tt = network_to_tt(network)
+
+    assert len(tt.node_list) == max(len(in_shape), len(out_shape))
+    assert len(tt.in_edges) == len(in_shape)
+    assert len(tt.out_edges) == len(out_shape)
+    assert len(tt.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
+    assert set(tt.nodes) == set(tt.node_list)
+    assert_in_edges_name(tt)
+    assert_out_edges_name(tt)
+    assert_bond_edges_name(tt)
+    assert_nodes_name(tt)
+    assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
+    assert_almost_equal(network.to_array(), tt.to_array())

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -4,7 +4,7 @@ import pytest
 
 from qutip.core import data
 from qutip.core.data import dense
-from qutip_tensornetwork.core.data import Network, FiniteTT, network_to_tt
+from qutip_tensornetwork.core.data import Network, FiniteTT
 from qutip_tensornetwork.testing import assert_network_close
 from .conftest import random_node, random_complex_network, random_one_node_network
 import tensornetwork as tn
@@ -219,37 +219,6 @@ class TestFrom_node_list:
 
             with pytest.raises(ValueError):
                 FiniteTT.from_node_list(list_tensors)
-
-
-@pytest.mark.parametrize(
-    "in_shape, out_shape",
-    [
-        ((2, 2, 2), (2, 2, 2)),
-        ((2, 2), (2, 2)),
-        ((2,), (2,)),
-        ((2, 2, 2), ()),
-        ((2,), ()),
-        ((), (2, 2, 2)),
-        ((), (2,)),
-    ],
-)
-def test_network_to_tt(in_shape, out_shape):
-    in_node = random_node(in_shape)
-    out_node = random_node(out_shape)
-    network = Network(out_node[:], in_node[:])
-    tt = network_to_tt(network)
-
-    assert len(tt.node_list) == max(len(in_shape), len(out_shape))
-    assert len(tt.in_edges) == len(in_shape)
-    assert len(tt.out_edges) == len(out_shape)
-    assert len(tt.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
-    assert set(tt.nodes) == set(tt.node_list)
-    assert_in_edges_name(tt)
-    assert_out_edges_name(tt)
-    assert_bond_edges_name(tt)
-    assert_nodes_name(tt)
-    assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
-    assert_almost_equal(network.to_array(), tt.to_array())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds a new class that can be used to represent tensor-trains (MPS and MPO). The idea is to eventually use this class to create a solver using the TEBD algorithm. It inherits from `Network` but addition, matmul, mul and tensor will be overridden in a future PR.

At this moment this class includes the `__init__` method together with the `from_node_list` as possibilities to create a new tt. It also includes a few convenient properties such as `bond_edges`, `node_lists` and `node_list` that are useful for iterating in the tt's components.

ALSO: I "protected" the nodes attribute by hiding it as a private property. The reason is that a user should not be able to add in any case a new node without using the appropriate method (mul, matmul, etc).
TODO:
- [x] Tests
- [x] PEP8 