### PR TITLE
Truncate

### DIFF
--- a/src/qutip_tensornetwork/core/data/network.py
+++ b/src/qutip_tensornetwork/core/data/network.py
@@ -191,7 +191,7 @@ class Network(qutip.core.data.Data):
         in_edges = [edge_dict[e] for e in self.in_edges]
         out_edges = [edge_dict[e] for e in self.out_edges]
 
-        return Network._fast_constructor(out_edges, in_edges, nodes)
+        return self._fast_constructor(out_edges, in_edges, nodes)
 
     @classmethod
     def _fast_constructor(cls, out_edges, in_edges, nodes):

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -236,27 +236,34 @@ class FiniteTT(Network):
 
     def truncate(self, bond_dimension=None, max_truncation_err=None):
         """Truncate in-place the bond dimension of the tensor train according
-        to ``bond_dimension``. This is done from left to right and once
-        finished the network is right normalized.
+        to ``bond_dimension`` and ``max_truncation_err``. If both are provided
+        ``bond_dimension`` takes precedence. The truncation error of the i-th
+        node may be larger than ``max_truncation_err[i]`` if required to
+        satisfy ``bond_dimension[i]``.
 
         Notes
         -----
         The truncation method consists of performing an SVD decomposition from
-        left to right and truncating each node's list of singular values as specified
-        (see the parameter descriptions below).
+        left to right and truncating each node's list of singular values as
+        specified (see the parameter descriptions below). Note that singular
+        values of i-th node are contracted to the i-th node. This means that
+        the result is _not_ in a canonical form.
 
         Parameters
         ----------
         bond_dimension: List of int or int
             List of integers that define, from left to right, the target bond
             dimension. If a single integer is provided is understood as the
-            same bond dimension for all bonds. None is understood as
-            "infinite" bond dimension and hence no truncation is done.
+            same bond dimension for all bonds. ``None`` is understood as "infinite"
+            bond dimension and hence is ignored.
 
         max_truncation_err: List of float or float
             Maximum truncation error for each individual node. If a single
             value is provided instead of a list, it is the assumed that the
-            same value applies for every node.
+            same value applies for every node. ``None`` is understood as 0 and
+            hence it is ignored. If both ``bond_dimension`` and
+            ``max_truncation_err`` are provided, ``bond_dimension`` takes
+            precedence.
 
         Returns
         -------
@@ -267,9 +274,9 @@ class FiniteTT(Network):
 
         See also
         --------
-        tensornetwork.split_node:
-            Function employed to split individual nodes. ``bond_dimension``
-            and ``max_truncation_err`` directly translate into
+        tensornetwork.split_node_full_svd:
+            Function employed to split individual nodes. ``bond_dimension`` and
+            ``max_truncation_err`` directly translate into
             ``max_singular_values`` and ``max_truncation_err``.
         """
         if not isinstance(bond_dimension, list):

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -241,8 +241,9 @@ class FiniteTT(Network):
 
         Notes
         -----
-        The truncation method consists on performing a svd decomposition from
-        left to right and truncating each nodes svd by the given parameters.
+        The truncation method consists of performing an SVD decomposition from
+        left to right and truncating each node's list of singular values as specified
+        (see the parameter descriptions below).
 
         Parameters
         ----------

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -363,7 +363,7 @@ def _check_shape(nodes):
     for i, node in enumerate(nodes[1:-1], start=2):
         if len(node.shape) != 1 + len(nodes[0].shape):
             raise ValueError(
-                f" the shape of the {i}-th node is not correct. It"
+                f"The shape of the {i}-th node is not correct. It"
                 f" has rank {len(node.shape)} but was expecting"
                 f" {len(nodes[0].shape) + 1}."
             )

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -259,8 +259,10 @@ class FiniteTT(Network):
 
         Returns
         -------
-        error: float
-            List of truncated singular values.
+        truncated_values: float
+            List of lists with the truncated singular values.
+            truncated_values[i] contains the truncated singular values for the
+            i-th node.
 
         See also
         --------
@@ -278,7 +280,7 @@ class FiniteTT(Network):
         if len(self.train_nodes) == 1:
             return []
 
-        total_error = []
+        truncated_values = []
         for i, bond_edge in enumerate(self.bond_edges):
 
             node = self.train_nodes[i]
@@ -301,7 +303,7 @@ class FiniteTT(Network):
                 max_singular_values=dim,
                 max_truncation_err=err,
             )
-            total_error += error.tolist()
+            truncated_values.append(error.tolist())
 
             # The next step is to contract the last two nodes to obtain the
             # network again in the tt format:
@@ -338,7 +340,7 @@ class FiniteTT(Network):
 
         self._nodes = set(new_nodes)
 
-        return total_error
+        return truncated_values
 
     @classmethod
     def _fast_constructor(cls, out_edges, in_edges, nodes):

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -286,14 +286,18 @@ class FiniteTT(Network):
             max_truncation_err = [max_truncation_err] * len(self.bond_edges)
 
         if len(max_truncation_err) != len(self.bond_edges):
-            raise ValueError(f"{len(max_truncation_err)} values where provided"
-                             " for `max_truncation_err` but there are"
-                             f" {len(self.bond_edges)} bond edges.")
+            raise ValueError(
+                f"{len(max_truncation_err)} values where provided"
+                " for `max_truncation_err` but there are"
+                f" {len(self.bond_edges)} bond edges."
+            )
 
         if len(bond_dimension) != len(self.bond_edges):
-            raise ValueError(f"{len(bond_dimension)} values where provided"
-                             " for `bond_dimension` but there are"
-                             f" {len(self.bond_edges)} bond edges.")
+            raise ValueError(
+                f"{len(bond_dimension)} values where provided"
+                " for `bond_dimension` but there are"
+                f" {len(self.bond_edges)} bond edges."
+            )
 
         if len(self.train_nodes) == 1:
             return []
@@ -302,7 +306,7 @@ class FiniteTT(Network):
         for i, bond_edge in enumerate(self.bond_edges):
 
             node = self.train_nodes[i]
-            next_node = self.train_nodes[i+1]
+            next_node = self.train_nodes[i + 1]
             dim = bond_dimension[i]
             err = max_truncation_err[i]
 
@@ -333,11 +337,10 @@ class FiniteTT(Network):
             # keep the singular values spread over the tensor train. Note that
             # the result will not be in a canonical form.
             edge_order = left_edges + [s[1]]
-            new_node = tn.contract_between(lnode, s,
-                                           output_edge_order=edge_order,
-                                           axis_names=node.axis_names)
+            new_node = tn.contract_between(
+                lnode, s, output_edge_order=edge_order, axis_names=node.axis_names
+            )
             new_node.name = node.name
-
 
             # We then contract rnode with next_node
             axis_names = next_node.axis_names
@@ -346,9 +349,12 @@ class FiniteTT(Network):
             edge_order += [new_node["rbond"]]  # This is the new "lbond" edge
             edge_order += [next_node["rbond"]] if "rbond" in axis_names else []
 
-            new_next_node = tn.contract_between(rnode, next_node,
-                                               output_edge_order=edge_order,
-                                               axis_names=next_node.axis_names)
+            new_next_node = tn.contract_between(
+                rnode,
+                next_node,
+                output_edge_order=edge_order,
+                axis_names=next_node.axis_names,
+            )
             new_next_node.name = next_node.name
 
         # We append the last node after the for loop as it does not need to be

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -279,12 +279,12 @@ class FiniteTT(Network):
             return []
 
         total_error = []
-        for bond_edge, dim, err in zip(
-            self.bond_edges, bond_dimension, max_truncation_err
-        ):
+        for i, bond_edge in enumerate(self.bond_edges):
 
-            node = bond_edge.node1
-            next_node = bond_edge.node2
+            node = self.train_nodes[i]
+            next_node = self.train_nodes[i+1]
+            dim = bond_dimension[i]
+            err = max_truncation_err[i]
 
             # We begin by performing the following (svd) transformation:
             #   |   |             |           |
@@ -320,9 +320,9 @@ class FiniteTT(Network):
 
             tn.contract(s[1])
             new_next_node = tn.contract(bond_edge)
+            new_next_node.name = next_node.name
             new_next_node.reorder_edges(edge_order)
             new_next_node.add_axis_names(axis_names)
-            new_next_node.name = next_node.name
 
         # We append the last node after the for loop as it does not need to be
         # truncated.

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -254,8 +254,8 @@ class FiniteTT(Network):
         bond_dimension: List of int or int
             List of integers that define, from left to right, the target bond
             dimension. If a single integer is provided is understood as the
-            same bond dimension for all bonds. ``None`` is understood as "infinite"
-            bond dimension and hence is ignored.
+            same bond dimension for all bonds. ``None`` is understood as
+            "infinite" bond dimension and hence is ignored.
 
         max_truncation_err: List of float or float
             Maximum truncation error for each individual node. If a single
@@ -284,6 +284,16 @@ class FiniteTT(Network):
 
         if not isinstance(max_truncation_err, list):
             max_truncation_err = [max_truncation_err] * len(self.bond_edges)
+
+        if len(max_truncation_err) != len(self.bond_edges):
+            raise ValueError(f"{len(max_truncation_err)} values where provided"
+                             " for `max_truncation_err` but there are"
+                             f" {len(self.bond_edges)} bond edges.")
+
+        if len(bond_dimension) != len(self.bond_edges):
+            raise ValueError(f"{len(bond_dimension)} values where provided"
+                             " for `bond_dimension` but there are"
+                             f" {len(self.bond_edges)} bond edges.")
 
         if len(self.train_nodes) == 1:
             return []

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -51,7 +51,7 @@ class FiniteTT(Network):
         in_edges and out_edges or scalar nodes, in which case they have no
         edges.
 
-    nodes_list: List of Nodes
+    train_nodes: List of Nodes
         Nodes of the tensor-train sorted from left to right.
     out_edges : list of Edges
         List of ``Edges`` to be used. When the network is considered as a
@@ -63,7 +63,7 @@ class FiniteTT(Network):
 
     bond_edges: List of Edges
         The edges between the nodes of the tensor-train. These are sorted from
-        left to right (i.e. ``nodes_list[i]["rbond"] == bond_edges[i]``).
+        left to right (i.e. ``train_nodes[i]["rbond"] == bond_edges[i]``).
 
     dims : list of int
         Dimension of the system as a list of lists. dims[0] represents the
@@ -260,7 +260,7 @@ class FiniteTT(Network):
         Returns
         -------
         error: float
-            Sum of truncated singular values.
+            List of truncated singular values.
 
         See also
         --------
@@ -275,7 +275,7 @@ class FiniteTT(Network):
         if not isinstance(max_truncation_err, list):
             max_truncation_err = [max_truncation_err] * len(self.bond_edges)
 
-        if len(self.node_list) == 1:
+        if len(self.train_nodes) == 1:
             return []
 
         total_error = []

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -234,7 +234,7 @@ class FiniteTT(Network):
 
         self._nodes = set(nodes)
 
-    def truncate(self, bond_dimension=None, max_truncation_err=None, relative=False):
+    def truncate(self, bond_dimension=None, max_truncation_err=None):
         """Truncate in-place the bond dimension of the tensor train according
         to ``bond_dimension``. This is done from left to right and once
         finished the network is right normalized.
@@ -318,7 +318,7 @@ class FiniteTT(Network):
             edge_order += [s[0]]  # This is the new bond edge
             edge_order += [next_node["rbond"]] if "rbond" in axis_names else []
 
-            new_next_node = tn.contract(s[1])
+            tn.contract(s[1])
             new_next_node = tn.contract(bond_edge)
             new_next_node.reorder_edges(edge_order)
             new_next_node.add_axis_names(axis_names)

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -317,6 +317,8 @@ class FiniteTT(Network):
             # where the edge between the nodes (left fig) is the bond_edge.
             # Note that the svd truncates the dimension of the new nodes.
             left_edges = [edge for edge in node if edge is not bond_edge]
+            left_edges = [node["out"], node["in"]]
+            left_edges += [node["lbond"]] if "lbond" in node.axis_names else []
             right_edges = [bond_edge]
             lnode, s, rnode, error = tn.split_node_full_svd(
                 node,

--- a/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
+++ b/src/qutip_tensornetwork/core/data/tensor_train/tensor_train.py
@@ -234,10 +234,8 @@ class FiniteTT(Network):
 
         self._nodes = set(nodes)
 
-
-    def truncate(self, bond_dimension=None, max_truncation_err = None,
-                 relative=False):
-        """ Truncate in-place the bond dimension of the tensor train according
+    def truncate(self, bond_dimension=None, max_truncation_err=None, relative=False):
+        """Truncate in-place the bond dimension of the tensor train according
         to ``bond_dimension``. This is done from left to right and once
         finished the network is right normalized.
 
@@ -281,8 +279,9 @@ class FiniteTT(Network):
             return []
 
         total_error = []
-        for bond_edge, dim, err in zip(self.bond_edges, bond_dimension,
-                                       max_truncation_err):
+        for bond_edge, dim, err in zip(
+            self.bond_edges, bond_dimension, max_truncation_err
+        ):
 
             node = bond_edge.node1
             next_node = bond_edge.node2
@@ -295,9 +294,13 @@ class FiniteTT(Network):
             # Note that the svd truncates the dimension of the new nodes.
             left_edges = [edge for edge in node if edge is not bond_edge]
             right_edges = [bond_edge]
-            lnode, s, rnode, error = tn.split_node_full_svd(node, left_edges, right_edges,
-                                               max_singular_values=dim,
-                                               max_truncation_err=err)
+            lnode, s, rnode, error = tn.split_node_full_svd(
+                node,
+                left_edges,
+                right_edges,
+                max_singular_values=dim,
+                max_truncation_err=err,
+            )
             total_error += error.tolist()
             lnode.name = node.name
             lnode.reorder_edges(left_edges + [s[0]])
@@ -312,7 +315,7 @@ class FiniteTT(Network):
             axis_names = next_node.axis_names
             edge_order = [next_node["out"]] if "out" in axis_names else []
             edge_order += [next_node["in"]] if "in" in axis_names else []
-            edge_order += [s[0]] # This is the new bond edge
+            edge_order += [s[0]]  # This is the new bond edge
             edge_order += [next_node["rbond"]] if "rbond" in axis_names else []
 
             new_next_node = tn.contract(s[1])
@@ -322,14 +325,13 @@ class FiniteTT(Network):
             new_next_node.name = next_node.name
 
         # We append the last node after the for loop as it does not need to be
-        # truncated. 
+        # truncated.
         new_nodes = [edge.node1 for edge in self.bond_edges]
         new_nodes += [self.bond_edges[-1].node2]
 
         self._nodes = set(new_nodes)
 
         return total_error
-
 
     @classmethod
     def _fast_constructor(cls, out_edges, in_edges, nodes):

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -283,7 +283,7 @@ class TestTruncate:
         error = mpo.truncate()
         assert len(error) == 0
         # The default values will truncate the final tensor train as the first
-        # few bond dimensions are lager than they need to be.
+        # few bond dimensions are larger than they need to be.
 
         assert len(mpo.train_nodes) == n
         assert len(mpo.in_edges) == n

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -36,15 +36,15 @@ def random_mpo(n, d, bond_dimension):
     """Create a random mpo with n sites d dimension per site and
     bond_dimesnion."""
     if n > 1:
-        list_tensors = [np.random.random((d, d, bond_dimension)) - 1 / 2]
+        list_tensors = [random_node((d, d, bond_dimension)) - 1 / 2]
         list_tensors += [
-            np.random.random((d, d, bond_dimension, bond_dimension)) - 1 / 2
+            random_node((d, d, bond_dimension, bond_dimension)) - 1 / 2
             for _ in range(n - 2)
         ]
-        list_tensors += [np.random.random((d, d, bond_dimension)) - 1 / 2]
+        list_tensors += [random_node((d, d, bond_dimension)) - 1 / 2]
         mpo = FiniteTT.from_nodes(list_tensors)
     elif n == 1:
-        node = tn.Node(np.random.random((d, d)))
+        node = tn.Node(random_node((d, d)))
         mpo = FiniteTT(node[0:1], node[1:])
     return mpo
 
@@ -137,9 +137,9 @@ class Test_node_list:
     def test_ket(self, n):
         d = 3
         chi = 10
-        list_tensors = [np.random.random((d, chi))]
-        list_tensors += [np.random.random((d, chi, chi)) for _ in range(n - 2)]
-        list_tensors += [np.random.random((d, chi))]
+        list_tensors = [random_node((d, chi))]
+        list_tensors += [random_node((d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [random_node((d, chi))]
 
         tt = FiniteTT.from_nodes(list_tensors)
 
@@ -155,14 +155,14 @@ class Test_node_list:
         assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
 
         for node_actual, node_desired in zip(tt.train_nodes, list_tensors):
-            assert (node_actual.tensor == node_desired).all()
+            assert (node_actual.tensor == node_desired.tensor).all()
 
     def test_op(self, n):
         d = 3
         chi = 10
-        list_tensors = [np.random.random((d, d, chi))]
-        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
-        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [random_node((d, d, chi))]
+        list_tensors += [random_node((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [random_node((d, d, chi))]
 
         tt = FiniteTT.from_nodes(list_tensors)
 
@@ -178,14 +178,14 @@ class Test_node_list:
         assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
 
         for node_actual, node_desired in zip(tt.train_nodes, list_tensors):
-            assert (node_actual.tensor == node_desired).all()
+            assert (node_actual.tensor == node_desired.tensor).all()
 
     def test_node(self, n):
         d = 3
         chi = 10
-        list_tensors = [np.random.random((d, d, chi))]
-        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
-        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [random_node((d, d, chi))]
+        list_tensors += [random_node((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [random_node((d, d, chi))]
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
         tt = FiniteTT.from_nodes(list_tensors)
@@ -207,9 +207,9 @@ class Test_node_list:
     def test_incorrect_bond_dim_raises(self, n):
         d = 3
         chi = 10
-        list_tensors = [np.random.random((d, d, chi + 1))]
-        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
-        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [random_node((d, d, chi + 1))]
+        list_tensors += [random_node((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [random_node((d, d, chi))]
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
         with pytest.raises(ValueError):
@@ -218,20 +218,20 @@ class Test_node_list:
     def test_incorrect_shape_raises(self, n):
         d = 3
         chi = 10
-        list_tensors = [np.random.random((d, d, chi, chi))]
-        list_tensors += [np.random.random((d, d, chi, chi)) for _ in range(n - 2)]
-        list_tensors += [np.random.random((d, d, chi))]
+        list_tensors = [random_node((d, d, chi, chi))]
+        list_tensors += [random_node((d, d, chi, chi)) for _ in range(n - 2)]
+        list_tensors += [random_node((d, d, chi))]
         list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
         with pytest.raises(ValueError):
             FiniteTT.from_nodes(list_tensors)
 
         if n > 2:
-            list_tensors = [np.random.random((d, d, chi))]
+            list_tensors = [random_node((d, d, chi))]
             list_tensors += [
-                np.random.random((d, d, chi, chi, 10)) for _ in range(n - 2)
+                random_node((d, d, chi, chi, 10)) for _ in range(n - 2)
             ]
-            list_tensors += [np.random.random((d, d, chi))]
+            list_tensors += [random_node((d, d, chi))]
             list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
             with pytest.raises(ValueError):

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -228,9 +228,7 @@ class Test_node_list:
 
         if n > 2:
             list_tensors = [random_node((d, d, chi))]
-            list_tensors += [
-                random_node((d, d, chi, chi, 10)) for _ in range(n - 2)
-            ]
+            list_tensors += [random_node((d, d, chi, chi, 10)) for _ in range(n - 2)]
             list_tensors += [random_node((d, d, chi))]
             list_tensors = [tn.Node(tensor) for tensor in list_tensors]
 
@@ -334,23 +332,28 @@ class TestTruncate:
         ]
         assert mpo.bond_dimension == expected_bond_dim[:n]
 
-    @pytest.mark.parametrize("n_bonds", [3,5])
+    @pytest.mark.parametrize("n_bonds", [3, 5])
     def test_raises_wrong_len_argument(self, n_bonds):
         bond_dimension = [2, 2, 2, 2]
-        mpo = random_mpo(n_bonds+1, 2, 10)
+        mpo = random_mpo(n_bonds + 1, 2, 10)
 
         with pytest.raises(ValueError) as e:
             mpo.truncate(bond_dimension=bond_dimension)
 
-        assert ("4 values where provided for `bond_dimension` but there"
-        f" are {n_bonds} bond edges." in str(e))
+        assert (
+            "4 values where provided for `bond_dimension` but there"
+            f" are {n_bonds} bond edges." in str(e)
+        )
 
-        max_truncation_err = [1., 1., 1., 1.]
+        max_truncation_err = [1.0, 1.0, 1.0, 1.0]
         with pytest.raises(ValueError) as e:
             mpo.truncate(max_truncation_err=max_truncation_err)
 
-        assert ("4 values where provided for `max_truncation_err` but there"
-        f" are {n_bonds} bond edges." in str(e))
+        assert (
+            "4 values where provided for `max_truncation_err` but there"
+            f" are {n_bonds} bond edges." in str(e)
+        )
+
 
 @pytest.mark.parametrize(
     "in_shape, out_shape",
@@ -383,6 +386,7 @@ def test_copy(in_shape, out_shape):
     assert copy.bond_dimension == [e.dimension for e in copy.bond_edges]
     assert_almost_equal(copy.to_array(), tt.to_array())
 
+
 def assert_no_truncation(truncate_values):
     for error in truncate_values:
-        assert len(error)==0
+        assert len(error) == 0

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -281,7 +281,7 @@ class TestTruncate:
         copy = mpo.copy()
 
         error = mpo.truncate()
-        assert len(error) == 0
+        assert_no_truncation(error)
         # The default values will truncate the final tensor train as the first
         # few bond dimensions are lager than they need to be.
 
@@ -365,3 +365,7 @@ def test_copy(in_shape, out_shape):
     assert_nodes_name(copy)
     assert copy.bond_dimension == [e.dimension for e in copy.bond_edges]
     assert_almost_equal(copy.to_array(), tt.to_array())
+
+def assert_no_truncation(truncate_values):
+    for error in truncate_values:
+        assert len(error)==0

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -334,6 +334,23 @@ class TestTruncate:
         ]
         assert mpo.bond_dimension == expected_bond_dim[:n]
 
+    @pytest.mark.parametrize("n_bonds", [3,5])
+    def test_raises_wrong_len_argument(self, n_bonds):
+        bond_dimension = [2, 2, 2, 2]
+        mpo = random_mpo(n_bonds+1, 2, 10)
+
+        with pytest.raises(ValueError) as e:
+            mpo.truncate(bond_dimension=bond_dimension)
+
+        assert ("4 values where provided for `bond_dimension` but there"
+        f" are {n_bonds} bond edges." in str(e))
+
+        max_truncation_err = [1., 1., 1., 1.]
+        with pytest.raises(ValueError) as e:
+            mpo.truncate(max_truncation_err=max_truncation_err)
+
+        assert ("4 values where provided for `max_truncation_err` but there"
+        f" are {n_bonds} bond edges." in str(e))
 
 @pytest.mark.parametrize(
     "in_shape, out_shape",

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -336,7 +336,7 @@ class TestTruncate():
         ((), (2,)),
     ],
 )
-def test_init_default_args(in_shape, out_shape):
+def test_copy(in_shape, out_shape):
     in_node = random_node(in_shape)
     out_node = random_node(out_shape)
     tt = FiniteTT(out_node[:], in_node[:])

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -42,7 +42,7 @@ def random_mpo(n, d, bond_dimension):
             for _ in range(n - 2)
         ]
         list_tensors += [np.random.random((d, d, bond_dimension)) - 1 / 2]
-        mpo = FiniteTT.from_node_list(list_tensors)
+        mpo = FiniteTT.from_nodes(list_tensors)
     elif n == 1:
         node = tn.Node(np.random.random((d, d)))
         mpo = FiniteTT(node[0:1], node[1:])
@@ -133,7 +133,7 @@ class TestInit:
 
 
 @pytest.mark.parametrize("n", [2, 3, 4])
-class Test_from_node_list:
+class Test_node_list:
     def test_ket(self, n):
         d = 3
         chi = 10
@@ -285,11 +285,11 @@ class TestTruncate:
         # The default values will truncate the final tensor train as the first
         # few bond dimensions are lager than they need to be.
 
-        assert len(mpo.node_list) == n
+        assert len(mpo.train_nodes) == n
         assert len(mpo.in_edges) == n
         assert len(mpo.out_edges) == n
         assert len(mpo.bond_edges) == n - 1
-        assert set(mpo.nodes) == set(mpo.node_list)
+        assert set(mpo.nodes) == set(mpo.train_nodes)
         assert_in_edges_name(mpo)
         assert_out_edges_name(mpo)
         assert_bond_edges_name(mpo)
@@ -308,15 +308,16 @@ class TestTruncate:
         mpo = random_mpo(n, 2, 100)
         copy = mpo.copy()
 
-        mpo.truncate(bond_dimension=truncated_bond_dimension)
+        error = mpo.truncate(bond_dimension=truncated_bond_dimension)
         # The default values will truncate the final tensor train as the first
         # few bond dimensions are lager than they need to be.
 
-        assert len(mpo.node_list) == n
+        assert isinstance(error, list)
+        assert len(mpo.train_nodes) == n
         assert len(mpo.in_edges) == n
         assert len(mpo.out_edges) == n
         assert len(mpo.bond_edges) == n - 1
-        assert set(mpo.nodes) == set(mpo.node_list)
+        assert set(mpo.nodes) == set(mpo.train_nodes)
         assert_in_edges_name(mpo)
         assert_out_edges_name(mpo)
         assert_bond_edges_name(mpo)
@@ -353,11 +354,11 @@ def test_copy(in_shape, out_shape):
     copy = tt.copy()
 
     assert isinstance(copy, FiniteTT)
-    assert len(copy.node_list) == max(len(in_shape), len(out_shape))
+    assert len(copy.train_nodes) == max(len(in_shape), len(out_shape))
     assert len(copy.in_edges) == len(in_shape)
     assert len(copy.out_edges) == len(out_shape)
     assert len(copy.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
-    assert set(copy.nodes) == set(copy.node_list)
+    assert set(copy.nodes) == set(copy.train_nodes)
     assert_in_edges_name(copy)
     assert_out_edges_name(copy)
     assert_bond_edges_name(copy)

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -354,3 +354,35 @@ class TestTruncate():
         expected_bond_dim = [min(d, truncation) for d, truncation in zip(expected_bond_dim,
                                                         truncated_bond_dimension)]
         assert mpo.bond_dimension == expected_bond_dim[:n]
+
+@pytest.mark.parametrize(
+    "in_shape, out_shape",
+    [
+        ((2, 2, 2), (2, 2, 2)),
+        ((2, 2), (2, 2)),
+        ((2,), (2,)),
+        ((2, 2, 2), ()),
+        ((2,), ()),
+        ((), (2, 2, 2)),
+        ((), (2,)),
+    ],
+)
+def test_init_default_args(in_shape, out_shape):
+    in_node = random_node(in_shape)
+    out_node = random_node(out_shape)
+    tt = FiniteTT(out_node[:], in_node[:])
+    copy = tt.copy()
+
+    assert isinstance(copy, FiniteTT)
+    assert len(copy.node_list) == max(len(in_shape), len(out_shape))
+    assert len(copy.in_edges) == len(in_shape)
+    assert len(copy.out_edges) == len(out_shape)
+    assert len(copy.bond_edges) == max(len(in_shape) - 1, len(out_shape) - 1)
+    assert set(copy.nodes) == set(copy.node_list)
+    assert_in_edges_name(copy)
+    assert_out_edges_name(copy)
+    assert_bond_edges_name(copy)
+    assert_nodes_name(copy)
+    assert copy.bond_dimension == [e.dimension for e in copy.bond_edges]
+    assert_almost_equal(copy.to_array(), tt.to_array())
+

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -417,7 +417,7 @@ class TestTruncate:
             [48.0, 47.0, 32.0, 31.0, 16.0, 15.0],
         ]
 
-        list_chi = [2] * (n - 1) # Bond dimension 2 for all bonds
+        list_chi = [2] * (n - 1)  # Bond dimension 2 for all bonds
         start = [d ** (2 * i) for i in range(1, n)] + [4]
         list_tensors = [
             arange_diag((d * d, list_chi[0]), start[0]).reshape((d, d, list_chi[0]))

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -31,6 +31,19 @@ def assert_bond_edges_name(tt):
         assert tt.node_list[i]["rbond"] is edge
         assert tt.node_list[i + 1]["lbond"] is edge
 
+def random_mpo(n, d, bond_dimension):
+    """Create a random mpo with n sites d dimension per site and
+    bond_dimesnion."""
+    if n>1:
+        list_tensors = [np.random.random((d, d, bond_dimension))-1/2]
+        list_tensors += [np.random.random((d, d, bond_dimension,
+                                           bond_dimension)) -1/2 for _ in range(n-2)]
+        list_tensors += [np.random.random((d, d, bond_dimension)) -1/2]
+        mpo = FiniteTT.from_node_list(list_tensors)
+    elif n==1:
+        node = tn.Node(np.random.random((d, d)))
+        mpo = FiniteTT(node[0:1], node[1:])
+    return mpo
 
 class TestInit:
     @pytest.mark.parametrize(
@@ -116,7 +129,7 @@ class TestInit:
 
 
 @pytest.mark.parametrize("n", [2, 3, 4])
-class TestFrom_node_list:
+class Test_from_node_list:
     def test_ket(self, n):
         d = 3
         chi = 10
@@ -276,3 +289,68 @@ def test_from_2d_array(shape, expected_dims):
     assert_nodes_name(tt)
     assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
     np.testing.assert_allclose(array, tt.to_array().reshape(shape))
+
+class TestTruncate():
+    """These tests do not ensure that the operation is mathematically correct
+    but rather that the resulting object is a tensor-train with proper
+    nodes/edges."""
+
+
+    @pytest.mark.parametrize("n", [5, 2, 1])
+    def test_default(self, n):
+        """We test that the default values return a tensor-train without any
+        truncation. Note that the actual bond_dimension may still change."""
+        # Create a random MPO
+        d = 2
+        bond_dimension = 100
+        mpo = random_mpo(n, d, bond_dimension)
+
+        copy = mpo.copy()
+
+        error = mpo.truncate()
+        assert len(error) == 0
+        # The default values will truncate the final tensor train as the first
+        # few bond dimensions are lager than they need to be.
+
+        assert len(mpo.node_list) == n
+        assert len(mpo.in_edges) == n
+        assert len(mpo.out_edges) == n
+        assert len(mpo.bond_edges) == n-1
+        assert set(mpo.nodes) == set(mpo.node_list)
+        assert_in_edges_name(mpo)
+        assert_out_edges_name(mpo)
+        assert_bond_edges_name(mpo)
+        assert_nodes_name(mpo)
+        expected_bond_dim = [4, 16, 64, 100, 100]
+        assert mpo.bond_dimension == expected_bond_dim[:n-1]
+        assert_almost_equal(copy.to_array(), mpo.to_array())
+
+
+    @pytest.mark.parametrize("truncated_bond_dimension", [10, [1, 2, 3, 4] ], ids=["int", "list"])
+    def test_truncate_bodn_dimension(self, truncated_bond_dimension):
+        """We test that the argument bond_dimension truncates the tt train to
+        return a tt with the specified bon_dimension."""
+        n=5
+        mpo = random_mpo(n, 2, 100)
+        copy = mpo.copy()
+
+        mpo.truncate(bond_dimension=truncated_bond_dimension)
+        # The default values will truncate the final tensor train as the first
+        # few bond dimensions are lager than they need to be.
+
+        assert len(mpo.node_list) == n
+        assert len(mpo.in_edges) == n
+        assert len(mpo.out_edges) == n
+        assert len(mpo.bond_edges) == n-1
+        assert set(mpo.nodes) == set(mpo.node_list)
+        assert_in_edges_name(mpo)
+        assert_out_edges_name(mpo)
+        assert_bond_edges_name(mpo)
+        assert_nodes_name(mpo)
+        expected_bond_dim = [4, 16, 64, 100]
+        if isinstance(truncated_bond_dimension,int):
+            truncated_bond_dimension = [truncated_bond_dimension]*len(expected_bond_dim)
+
+        expected_bond_dim = [min(d, truncation) for d, truncation in zip(expected_bond_dim,
+                                                        truncated_bond_dimension)]
+        assert mpo.bond_dimension == expected_bond_dim[:n]

--- a/tests/core/data/test_tensor_train.py
+++ b/tests/core/data/test_tensor_train.py
@@ -31,19 +31,23 @@ def assert_bond_edges_name(tt):
         assert tt.train_nodes[i]["rbond"] is edge
         assert tt.train_nodes[i + 1]["lbond"] is edge
 
+
 def random_mpo(n, d, bond_dimension):
     """Create a random mpo with n sites d dimension per site and
     bond_dimesnion."""
-    if n>1:
-        list_tensors = [np.random.random((d, d, bond_dimension))-1/2]
-        list_tensors += [np.random.random((d, d, bond_dimension,
-                                           bond_dimension)) -1/2 for _ in range(n-2)]
-        list_tensors += [np.random.random((d, d, bond_dimension)) -1/2]
+    if n > 1:
+        list_tensors = [np.random.random((d, d, bond_dimension)) - 1 / 2]
+        list_tensors += [
+            np.random.random((d, d, bond_dimension, bond_dimension)) - 1 / 2
+            for _ in range(n - 2)
+        ]
+        list_tensors += [np.random.random((d, d, bond_dimension)) - 1 / 2]
         mpo = FiniteTT.from_node_list(list_tensors)
-    elif n==1:
+    elif n == 1:
         node = tn.Node(np.random.random((d, d)))
         mpo = FiniteTT(node[0:1], node[1:])
     return mpo
+
 
 class TestInit:
     @pytest.mark.parametrize(
@@ -259,11 +263,11 @@ def test_from_2d_array(shape, expected_dims):
     assert tt.bond_dimension == [e.dimension for e in tt.bond_edges]
     np.testing.assert_allclose(array, tt.to_array().reshape(shape))
 
-class TestTruncate():
+
+class TestTruncate:
     """These tests do not ensure that the operation is mathematically correct
     but rather that the resulting object is a tensor-train with proper
     nodes/edges."""
-
 
     @pytest.mark.parametrize("n", [5, 2, 1])
     def test_default(self, n):
@@ -284,22 +288,23 @@ class TestTruncate():
         assert len(mpo.node_list) == n
         assert len(mpo.in_edges) == n
         assert len(mpo.out_edges) == n
-        assert len(mpo.bond_edges) == n-1
+        assert len(mpo.bond_edges) == n - 1
         assert set(mpo.nodes) == set(mpo.node_list)
         assert_in_edges_name(mpo)
         assert_out_edges_name(mpo)
         assert_bond_edges_name(mpo)
         assert_nodes_name(mpo)
         expected_bond_dim = [4, 16, 64, 100, 100]
-        assert mpo.bond_dimension == expected_bond_dim[:n-1]
+        assert mpo.bond_dimension == expected_bond_dim[: n - 1]
         assert_almost_equal(copy.to_array(), mpo.to_array())
 
-
-    @pytest.mark.parametrize("truncated_bond_dimension", [10, [1, 2, 3, 4] ], ids=["int", "list"])
+    @pytest.mark.parametrize(
+        "truncated_bond_dimension", [10, [1, 2, 3, 4]], ids=["int", "list"]
+    )
     def test_truncate_bodn_dimension(self, truncated_bond_dimension):
         """We test that the argument bond_dimension truncates the tt train to
         return a tt with the specified bon_dimension."""
-        n=5
+        n = 5
         mpo = random_mpo(n, 2, 100)
         copy = mpo.copy()
 
@@ -310,19 +315,24 @@ class TestTruncate():
         assert len(mpo.node_list) == n
         assert len(mpo.in_edges) == n
         assert len(mpo.out_edges) == n
-        assert len(mpo.bond_edges) == n-1
+        assert len(mpo.bond_edges) == n - 1
         assert set(mpo.nodes) == set(mpo.node_list)
         assert_in_edges_name(mpo)
         assert_out_edges_name(mpo)
         assert_bond_edges_name(mpo)
         assert_nodes_name(mpo)
         expected_bond_dim = [4, 16, 64, 100]
-        if isinstance(truncated_bond_dimension,int):
-            truncated_bond_dimension = [truncated_bond_dimension]*len(expected_bond_dim)
+        if isinstance(truncated_bond_dimension, int):
+            truncated_bond_dimension = [truncated_bond_dimension] * len(
+                expected_bond_dim
+            )
 
-        expected_bond_dim = [min(d, truncation) for d, truncation in zip(expected_bond_dim,
-                                                        truncated_bond_dimension)]
+        expected_bond_dim = [
+            min(d, truncation)
+            for d, truncation in zip(expected_bond_dim, truncated_bond_dimension)
+        ]
         assert mpo.bond_dimension == expected_bond_dim[:n]
+
 
 @pytest.mark.parametrize(
     "in_shape, out_shape",
@@ -354,4 +364,3 @@ def test_copy(in_shape, out_shape):
     assert_nodes_name(copy)
     assert copy.bond_dimension == [e.dimension for e in copy.bond_edges]
     assert_almost_equal(copy.to_array(), tt.to_array())
-


### PR DESCRIPTION
This PR includes a new method `truncate`  together with some small fixed for the tensor train class.

A few notes on this method. Tests currently ensure that the output makes sense as a tensor train. They also ensure that the bond dimension o the output has been truncated. I have not been able to design a test that numerically checks for the accuracy of the truncation step though. The issue here is that I could not think of an easy analytical example to compare to. Also the "error" returned does not accurately reproduce (and it should not) the expected error obtained from the norm of `truncated_state - state`. Which makes it difficult to relate those two values in a test.

The tensor train is left in a right normalized state. This means that the nodes are now unitary matrices (when shaped correctly). However, I am worried that a truncation with only a right normalization may not be enough. I am worried in particular for the case of using max_trunc_error. The point is that after truncating it for the first time, the all nodes are unitary and hence have a degenerate set of singular values equal to one. I am wondering how another truncation will affect the normalized state. The point is that if you have to get rid of a few singular values but all are the same... how do you know which one is bet to get rid of? I guess this should never happen in practice as you should only truncate the tensor train once the bond dimension has increased and hence the singular values will probably not be degenerated any-more. I guess this will come out again once matmul is included. For the moment lets just merge as it is and we will improve it later if needed.


Changelog:
- New method truncate added: it performs from left to right and svd truncation in the nodes of a tensor train. 
- Copy method fixed: previously it returned a Network not a tensortrain.